### PR TITLE
Fixed a simple bug in get_config (missing comma)

### DIFF
--- a/recurrentshop/engine.py
+++ b/recurrentshop/engine.py
@@ -419,7 +419,7 @@ class RecurrentContainer(Layer):
 		pass
 
 	def get_config(self):
-		attribs = ['return_sequences', 'go_backwards', 'stateful', 'readout', 'state_sync', 'decode', 'input_length', 'unroll' 'output_length']
+		attribs = ['return_sequences', 'go_backwards', 'stateful', 'readout', 'state_sync', 'decode', 'input_length', 'unroll', 'output_length']
 		config = {x : getattr(self, x) for x in attribs}
 		config['model'] = self.model.get_config()
 		base_config = super(RecurrentContainer, self).get_config()


### PR DESCRIPTION
Easy-to-miss mistake that happens to break the code was introduced in https://github.com/datalogai/recurrentshop/commit/6f709f1aabd5156b184a06852b8edb9ceee5bb21