### PR TITLE
fix keras requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-keras==1.1.0
+keras>=2.0.0
 numpy>=1.8.0
 theano>=0.8.0


### PR DESCRIPTION
I think recurrentshop 1.0.0 requires keras 2.0.0 or later.